### PR TITLE
Add Vagrant configuration to define the local testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vagrant
+vagrant.pub
+site.retry

--- a/README.md
+++ b/README.md
@@ -6,16 +6,13 @@ This infrastructure uses [Ansible](https://www.ansible.com/) ([docs](http://docs
 
 * Python 2.7+/3.5+
 * A copy of Ansible 2.4+ (`pip install ansible`)
-* A VM running Debian, for local testing changes to deployments
+* Vagrant 2+ and VirtualBox 5.1+, for local testing changes to deployments
 
 ## Testing changes locally
 
-1. Create a VM running Debian 8 (vm2) or 9 (vm1). **To prevent accidental
-   production deployment, do *not* use the same password for this account that
-   you use in production.**
-2. Install your SSH key into the default account in the VM
-3. Update `staging.yml` with the correct hosts for your dev environment
-4. Run `ansible-playbook -i staging.yml site.yml`
+1. Run `vagrant up` to create a control virtual machine (ansible) and two deployment targets (vm1 and vm2)
+2. Run `vagrant ssh ansible` to connect to the control virtual machine
+3. Run `cd /vagrant && ansible-playbook -b --ask-vault-pass -i staging.yml site.yml`
 
 ## Provisioning a new server
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,43 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.define "ansible" do |ansible|
+    ansible.vm.box = "debian/contrib-stretch64"
+    ansible.vm.network "private_network", ip: "192.168.10.100"
+
+    ansible.vm.provision "shell", inline: <<-SHELL
+      apt-get update
+      apt-get install -y python-pip
+      pip install ansible
+SHELL
+
+    ansible.vm.provision "shell", privileged: false, inline: <<-SHELL
+      echo "[defaults]
+host_key_checking = False
+
+[ssh_connection]
+pipelining = True" > ~/.ansible.cfg
+SHELL
+
+    ansible.vm.provision "shell", privileged: false, inline: <<-SHELL
+      ssh-keygen -N "" -f ~/.ssh/id_rsa -q
+      cp ~/.ssh/id_rsa.pub /vagrant/vagrant.pub
+SHELL
+
+  end
+
+  config.vm.define "vm1" do |vm1|
+    vm1.vm.box = "debian/contrib-stretch64"
+    vm1.vm.network "private_network", ip: "192.168.10.2"
+  end
+
+  config.vm.define "vm2" do |vm2|
+    vm2.vm.box = "debian/contrib-jessie64"
+    vm2.vm.network "private_network", ip: "192.168.10.3"
+  end
+
+  (1..2).each do |i|
+    config.vm.define "vm#{i}" do |node|
+      node.vm.provision "shell", privileged: false, inline: "cat /vagrant/vagrant.pub >> ~/.ssh/authorized_keys"
+    end
+  end
+end

--- a/staging.yml
+++ b/staging.yml
@@ -24,3 +24,5 @@ all:
     users:
       - name: user
         groups: sudo
+      - name: vagrant
+        groups: sudo


### PR DESCRIPTION
Use Vagrant to make the local environment reproducible, and hopefully to make it easier for new contributors.